### PR TITLE
Drop the min required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 
 #set(CMAKE_CXX_COMPILER "clang++")
 #set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fsycl")


### PR DESCRIPTION
Drop the min required cmake version to support building under 20.04