### PR TITLE
Fix KS21 pointcloud viz. KS21i cameras now have color cameras

### DIFF
--- a/src/CRLCamera/CRLPhysicalCamera.cpp
+++ b/src/CRLCamera/CRLPhysicalCamera.cpp
@@ -336,9 +336,8 @@ namespace VkRender::MultiSense {
 
         // TODO I want to update most info on startup but this function varies. On KS21 this will always fail.
         //  This also assumes that getDeviceInfo above also succeeded
-        if (infoMap[channelID].devInfo.hardwareRevision !=
-            crl::multisense::system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21 || infoMap[channelID].devInfo.hardwareRevision !=
-                                                                                 crl::multisense::system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21i) {
+        if (infoMap[channelID].devInfo.hardwareRevision != crl::multisense::system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21)
+        {
             allSucceeded &= updateAndLog([&](auto &data) { return channelPtr->getAuxImageConfig(data); },
                                          info.auxImgConf, "auxImageConfig");
         }

--- a/src/CRLCamera/CameraConnection.cpp
+++ b/src/CRLCamera/CameraConnection.cpp
@@ -864,7 +864,8 @@ namespace VkRender::MultiSense {
                     info.hardwareRevision ==
                     crl::multisense::system::DeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27 ||
                     info.hardwareRevision == crl::multisense::system::DeviceInfo::HARDWARE_REV_MULTISENSE_S30 ||
-                    info.hardwareRevision == crl::multisense::system::DeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM;
+                    info.hardwareRevision == crl::multisense::system::DeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM ||
+                    info.hardwareRevision == crl::multisense::system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21i;
 
             app->m_FailedGetStatusCount = 0;
             app->queryStatusTimer = std::chrono::steady_clock::now();


### PR DESCRIPTION
Only KS21 cameras do not have a color image. 

The logic for this should have also been `not ks21 and not ks21i` instead of `or`